### PR TITLE
Generate a Routes.ts file with types (good for client libraries), Support for Semantic Release

### DIFF
--- a/.github/workflows/npm-semantic-release.yml
+++ b/.github/workflows/npm-semantic-release.yml
@@ -1,0 +1,26 @@
+name: NPM Semantic Release
+on:
+  push:
+    branches:
+      - main
+jobs:
+  publish:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    name: Release
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Install dependencies
+        run: cd packages/nextlove && yarn install
+      - run: cd packages/nextlove && yarn build
+      - name: Release
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.SEAMAPI_NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: cd packages/nextlove && npx semantic-release

--- a/apps/example-todo-app/package.json
+++ b/apps/example-todo-app/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "rimraf dist && nsm build && tsup ./index.ts --dts --sourcemap && cp -r .next dist/.next",
     "build:openapi": "nextlove generate-openapi --packageDir . --apiName 'Example TODO API'",
+    "build:type": "nextlove generate-route-types --packageDir .",
     "start": "next start",
     "lint": "next lint",
     "test": "ava"

--- a/packages/nextlove/bin.js
+++ b/packages/nextlove/bin.js
@@ -9,15 +9,16 @@ const { unregister } = register({
 
 if (argv.help || argv.h) {
   console.log(
-`
-nextlove generate-openapi [options]
+    `
+nextlove (generate-openapi | generate-route-types) [options]
 
   --packageDir <path>  Path to the package directory containing the Next.js app
   --outputFile <path>  Path to the output file
   --pathGlob <glob>    Glob pattern to find API route files
   --apiPrefix <path>   Prefix for API routes, default: "/"
 
-`.trim())
+`.trim()
+  )
   process.exit(0)
 }
 
@@ -32,6 +33,22 @@ if (argv._[0] === "generate-openapi") {
 
   require("./dist/generate-openapi")
     .generateOpenAPI(argv)
+    .then((result) => {
+      if (!argv.outputFile) {
+        console.log(result)
+      }
+    })
+} else if (argv._[0] === "generate-route-types") {
+  if (argv._.length === 2) {
+    argv.packageDir = argv._[1]
+  }
+  if (argv["package-dir"]) {
+    argv.packageDir = argv["package-dir"]
+  }
+  if (!argv["packageDir"]) throw new Error("Missing --packageDir")
+
+  require("./dist/generate-route-types")
+    .generateRouteTypes(argv)
     .then((result) => {
       if (!argv.outputFile) {
         console.log(result)

--- a/packages/nextlove/package.json
+++ b/packages/nextlove/package.json
@@ -38,6 +38,7 @@
     "@anatine/zod-openapi": "^1.10.0",
     "@types/lodash": "^4.14.182",
     "@types/node": "18.0.0",
+    "@types/prettier": "^2.7.1",
     "@types/react": "18.0.14",
     "@types/react-dom": "18.0.5",
     "chalk": "^5.1.2",
@@ -48,9 +49,11 @@
     "minimist": "^1.2.7",
     "nextjs-middleware-wrappers": "^1.3.0",
     "openapi3-ts": "^3.1.1",
+    "prettier": "^2.7.1",
     "ts-toolbelt": "^9.6.0",
     "turbo": "^1.3.1",
     "type-fest": "^3.1.0",
-    "typescript": "4.7.4"
+    "typescript": "4.7.4",
+    "zod-to-ts": "^1.1.1"
   }
 }

--- a/packages/nextlove/release.config.js
+++ b/packages/nextlove/release.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  branches: ["main"],
+  plugins: [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    ["@semantic-release/npm", { npmPublish: true }],
+    [
+      "@semantic-release/git",
+      {
+        assets: ["package.json"],
+        message:
+          "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
+      },
+    ],
+  ],
+}

--- a/packages/nextlove/src/generate-route-types/index.ts
+++ b/packages/nextlove/src/generate-route-types/index.ts
@@ -1,5 +1,7 @@
 import { defaultMapFilePathToHTTPRoute } from "../lib/default-map-file-path-to-http-route"
 import { parseRoutesInPackage } from "../lib/parse-routes-in-package"
+import { zodToTs, printNode } from "zod-to-ts"
+import prettier from "prettier"
 
 interface GenerateRouteTypesOpts {
   packageDir: string
@@ -11,4 +13,51 @@ interface GenerateRouteTypesOpts {
 
 export const generateRouteTypes = async (opts: GenerateRouteTypesOpts) => {
   const filepathToRoute = await parseRoutesInPackage(opts)
+
+  // TODO when less lazy, use ts-morph for better generation
+  const routeDefs: string[] = []
+  for (const [_, { route, routeSpec }] of filepathToRoute) {
+    routeDefs.push(
+      `
+"${route}": {
+  route: "${route}",
+  method: ${routeSpec.methods.map((m) => `"${m}"`).join(" | ")},
+  queryParams: ${
+    routeSpec.queryParams
+      ? printNode(zodToTs(routeSpec.queryParams).node)
+      : "{}"
+  },
+  jsonBody: ${
+    routeSpec.jsonBody ? printNode(zodToTs(routeSpec.jsonBody).node) : "never"
+  },
+  commonParams: ${
+    routeSpec.commonParams
+      ? printNode(zodToTs(routeSpec.commonParams).node)
+      : "{}"
+  },
+  jsonResponse: ${
+    routeSpec.jsonResponse
+      ? printNode(zodToTs(routeSpec.jsonResponse).node)
+      : "{}"
+  }
+}`.trim()
+    )
+  }
+  const routeDefStr = routeDefs.join(",\n")
+  return prettier.format(
+    `export interface Routes {
+${routeDefStr}
+}
+
+export type RouteResponse<Path extends keyof Routes> =
+  Routes[Path]["jsonResponse"]
+
+export type RouteRequestBody<Path extends keyof Routes> =
+  Routes[Path]["jsonBody"] & Routes[Path]["commonParams"]
+
+export type RouteRequestParams<Path extends keyof Routes> =
+  Routes[Path]["queryParams"] & Routes[Path]["commonParams"]
+`.trim(),
+    { semi: false, parser: "typescript" }
+  )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -241,6 +241,11 @@
   resolved "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
 
+"@types/prettier@^2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.1.tgz#dfd20e2dc35f027cdd6c1908e80a5ddc7499670e"
+  integrity sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==
+
 "@types/prop-types@*":
   version "15.7.5"
   resolved "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz"


### PR DESCRIPTION
- checkpoint semantic release
- typegen working with zod conversion

## Example

```ts
export interface Routes {
  "/api/todo/add": {
    route: "/api/todo/add"
    method: "POST"
    queryParams: {}
    jsonBody: {
      id?: string
      title: string
      completed?: boolean
    }
    commonParams: {}
    jsonResponse: {
      ok: boolean
    }
  }
  "/api/todo/delete": {
    route: "/api/todo/delete"
    method: "DELETE"
    queryParams: {}
    jsonBody: {
      id: string
    }
    commonParams: {}
    jsonResponse: {
      ok: boolean
    }
  }
  "/api/todo/get": {
    route: "/api/todo/get"
    method: "GET"
    queryParams: {
      id: string
    }
    jsonBody: never
    commonParams: {}
    jsonResponse: {
      ok: boolean
      todo: {
        id: string
      }
    }
  }
}

export type RouteResponse<Path extends keyof Routes> =
  Routes[Path]["jsonResponse"]

export type RouteRequestBody<Path extends keyof Routes> =
  Routes[Path]["jsonBody"] & Routes[Path]["commonParams"]

export type RouteRequestParams<Path extends keyof Routes> =
  Routes[Path]["queryParams"] & Routes[Path]["commonParams"]
```