### PR TITLE
Make zod peer dependency

### DIFF
--- a/packages/nextlove/package.json
+++ b/packages/nextlove/package.json
@@ -21,6 +21,9 @@
     "build": "tsup --dts --sourcemap inline src",
     "yalc": "npm run build && yalc push"
   },
+  "peerDependencies": {
+    "zod": "^3"
+  },
   "dependencies": {
     "esbuild": "^0.14.7",
     "esbuild-runner": "^2.2.1",
@@ -31,7 +34,6 @@
     "nextjs-server-modules": "^1.7.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "zod": "^3.17.3",
     "zod-to-ts": "^1.1.1"
   },
   "devDependencies": {
@@ -56,6 +58,6 @@
     "turbo": "^1.3.1",
     "type-fest": "^3.1.0",
     "typescript": "4.7.4",
-    "zod-to-ts": "^1.1.1"
+    "zod": "^3.17.3"
   }
 }


### PR DESCRIPTION
Zod is directly imported by nextlove consumers, so this needs to be a peer rather than a direct dependency.
