### PR TITLE
fix: use type for route-types generation

### DIFF
--- a/packages/nextlove/src/generate-route-types/index.ts
+++ b/packages/nextlove/src/generate-route-types/index.ts
@@ -60,7 +60,7 @@ export const generateRouteTypes = async (opts: GenerateRouteTypesOpts) => {
   }
   const routeDefStr = routeDefs.join(",\n")
   const output = prettier.format(
-    `export interface Routes {
+    `export type Routes = {
 ${routeDefStr}
 }
 


### PR DESCRIPTION
This enables compatibility with https://github.com/seamapi/typed-axios