### PR TITLE
Move openapi3-ts to dependencies

### DIFF
--- a/packages/nextlove/package.json
+++ b/packages/nextlove/package.json
@@ -34,6 +34,7 @@
     "lodash": "^4.17.21",
     "nextjs-exception-middleware": "^2.0.1",
     "nextjs-middleware-wrappers": "^1.3.0",
+    "openapi3-ts": "^3.1.1",
     "zod-to-ts": "^1.1.1"
   },
   "devDependencies": {
@@ -53,7 +54,6 @@
     "next": "12.2.0",
     "nextjs-middleware-wrappers": "^1.3.0",
     "nextjs-server-modules": "^2.1.0",
-    "openapi3-ts": "^3.1.1",
     "prettier": "^2.7.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",


### PR DESCRIPTION
Should be a normal dependency: https://github.com/seamapi/nextlove/blob/main/packages/nextlove/src/generate-openapi/index.ts#L6-L10