### PR TITLE
fix: Add esbuild-register to peerDependencies

### DIFF
--- a/packages/nextlove/package.json
+++ b/packages/nextlove/package.json
@@ -22,6 +22,7 @@
     "yalc": "npm run build && yalc push"
   },
   "peerDependencies": {
+    "esbuild-register": ">=3",
     "next": ">=12",
     "react": ">=18",
     "react-dom": ">=18",


### PR DESCRIPTION
Running the CLI tools fail without this. The CLI should probably be moved to it's own package: `nextlove-cli` so consumers do not have to deploy esbuild into production. 