### PR TITLE
fix: Fix docs for default api prefix

### DIFF
--- a/packages/nextlove/bin.js
+++ b/packages/nextlove/bin.js
@@ -15,7 +15,7 @@ nextlove (generate-openapi | generate-route-types) [options]
   --packageDir <path>  Path to the package directory containing the Next.js app
   --outputFile <path>  Path to the output file
   --pathGlob <glob>    Glob pattern to find API route files
-  --apiPrefix <path>   Prefix for API routes, default: "/"
+  --apiPrefix <path>   Prefix for API routes, default: "/api"
 
 `.trim()
   )

--- a/packages/nextlove/src/generate-openapi/index.ts
+++ b/packages/nextlove/src/generate-openapi/index.ts
@@ -25,6 +25,7 @@ interface GenerateOpenAPIOpts {
   outputFile?: string
   pathGlob?: string
   tags?: Array<TagOption>
+  apiPrefix?: string
   mapFilePathToHTTPRoute?: (file_path: string) => string
 }
 


### PR DESCRIPTION
- Add missing apiPrefix option to type
- Correct docs for apiPrefix default value
