### PR TITLE
fix: jsonResponse doesn't assume ZodObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ export default withRouteSpec(routeSpec)(async (req, res) => {
 | `queryParams` | Any GET query parameters on the request as a zod object |
 | `jsonBody` | The JSON body this endpoint accepts as a zod object |
 | `commonParams` | Parameters common to both the query and json body as a zod object, this is sometimes used if a GET route also accepts POST |
-| `jsonResponse` | A zod object representing the json resposne |
+| `jsonResponse` | A zod object representing the json response |
 
 ### Generating OpenAPI Types (Command Line)
 

--- a/packages/nextlove/src/generate-openapi/index.ts
+++ b/packages/nextlove/src/generate-openapi/index.ts
@@ -141,8 +141,10 @@ export async function generateOpenAPI(opts: GenerateOpenAPIOpts) {
       route.responses[200].content = {
         "application/json": {
           schema: generateSchema(
-            addOkStatus
-              ? jsonResponse.extend({ ok: z.boolean() })
+            addOkStatus && jsonResponse._def.typeName === "ZodObject"
+              ? (jsonResponse as z.ZodObject<any, any, any, any, any>).extend({
+                  ok: z.boolean(),
+                })
               : jsonResponse
           ),
         },

--- a/packages/nextlove/src/generate-route-types/index.ts
+++ b/packages/nextlove/src/generate-route-types/index.ts
@@ -3,7 +3,7 @@ import { defaultMapFilePathToHTTPRoute } from "../lib/default-map-file-path-to-h
 import { parseRoutesInPackage } from "../lib/parse-routes-in-package"
 import { zodToTs, printNode } from "zod-to-ts"
 import prettier from "prettier"
-import { z } from "zod"
+import { ZodObject, z } from "zod"
 
 interface GenerateRouteTypesOpts {
   packageDir: string
@@ -48,8 +48,11 @@ export const generateRouteTypes = async (opts: GenerateRouteTypesOpts) => {
     routeSpec.jsonResponse
       ? printNode(
           zodToTs(
-            setupParams.addOkStatus
-              ? routeSpec.jsonResponse.extend({ ok: z.boolean() })
+            setupParams.addOkStatus &&
+              routeSpec.jsonResponse._def.typeName == "ZodObject"
+              ? (
+                  routeSpec.jsonResponse as ZodObject<any, any, any, any, any>
+                ).extend({ ok: z.boolean() })
               : routeSpec.jsonResponse
           ).node
         )

--- a/packages/nextlove/src/types/index.ts
+++ b/packages/nextlove/src/types/index.ts
@@ -18,7 +18,7 @@ export interface RouteSpec<
   QueryParams extends ParamDef = z.ZodTypeAny,
   CommonParams extends ParamDef = z.ZodTypeAny,
   Middlewares extends readonly Middleware<any, any>[] = any[],
-  JsonResponse extends ParamDef = z.ZodObject<any, any, any, any, any>,
+  JsonResponse extends ParamDef = z.ZodTypeAny,
   FormData extends ParamDef = z.ZodTypeAny
 > {
   methods: Methods


### PR DESCRIPTION
Close #60 

Checks if json response is a zod json object schema or not by checking the zod schema definition typeName. It's a bit of a weird feature that I found after doing some digging here https://github.com/colinhacks/zod/pull/523

I also haven't tested this yet. If someone can explain how to do that, would appreciate it. 
