### PR TITLE
`jsonResponse` should be a Zod schema

### DIFF
--- a/apps/example-todo-app/pages/api/todo/json-response-must-be-schema.ts
+++ b/apps/example-todo-app/pages/api/todo/json-response-must-be-schema.ts
@@ -12,14 +12,10 @@ export const route_spec = {
   methods: ["POST"],
   auth: "auth_token",
   jsonBody,
-  jsonResponse: z.object({
+  jsonResponse: {
     ok: z.string(),
-  }),
+  },
 } as const
 
-export default withRouteSpec(route_spec)(async (req, res) => {
-  return res.status(200).json({
-    // @ts-ignore
-    ok: true,
-  })
-})
+// @ts-expect-error
+export default withRouteSpec(route_spec)(async (req, res) => {})

--- a/packages/nextlove/src/types/index.ts
+++ b/packages/nextlove/src/types/index.ts
@@ -138,6 +138,17 @@ export type CreateWithRouteSpecFunction = <
   SP extends SetupParams<AuthMiddlewares, any>
 >(
   setupParams: SP
-) => <RS extends RouteSpec<any, any, any, any, any, any, any, any>>(
+) => <
+  RS extends RouteSpec<
+    string,
+    any,
+    any,
+    any,
+    any,
+    any,
+    z.ZodObject<any, any, any, any, any>,
+    any
+  >
+>(
   route_spec: RS
 ) => (next: RouteFunction<SP, RS>) => any


### PR DESCRIPTION
`withRouteSpec()` previously didn't error if `jsonResponse` was a plain JS object.
