### PR TITLE
Reduce bundle size

### DIFF
--- a/packages/nextlove/package.json
+++ b/packages/nextlove/package.json
@@ -27,8 +27,8 @@
     "react": ">=18",
     "react-dom": ">=18",
     "nextjs-server-modules": ">=1",
-    "zod": "^3",
-    "prettier": "^2"
+    "zod": "^3.0.0",
+    "prettier": "^2.0.0 || ^3.0.0"
   },
   "dependencies": {
     "lodash": "^4.17.21",

--- a/packages/nextlove/package.json
+++ b/packages/nextlove/package.json
@@ -27,7 +27,8 @@
     "react": ">=18",
     "react-dom": ">=18",
     "nextjs-server-modules": ">=1",
-    "zod": "^3"
+    "zod": "^3",
+    "prettier": "^2"
   },
   "dependencies": {
     "lodash": "^4.17.21",


### PR DESCRIPTION
The built `index.js` was inflated from under 1MB to 25MB in v2.1.0 because Prettier was being bundled.
