### PR TITLE
switch to readonly array for array formats

### DIFF
--- a/apps/example-todo-app/lib/middlewares/with-route-spec.ts
+++ b/apps/example-todo-app/lib/middlewares/with-route-spec.ts
@@ -1,4 +1,4 @@
-import { createWithRouteSpec, QueryArrayFormat } from "nextlove"
+import { createWithRouteSpec, QueryArrayFormats } from "nextlove"
 import { withAuthToken } from "./with-auth-token"
 export { checkRouteSpec } from "nextlove"
 import * as ZT from "lib/zod"
@@ -18,7 +18,7 @@ const defaultRouteSpec = {
 export const withRouteSpec = createWithRouteSpec(defaultRouteSpec)
 
 export const withRouteSpecSupportedArrayFormats = (
-  supportedArrayFormats: QueryArrayFormat[]
+  supportedArrayFormats: QueryArrayFormats
 ) =>
   createWithRouteSpec({
     ...defaultRouteSpec,

--- a/packages/nextlove/src/types/index.ts
+++ b/packages/nextlove/src/types/index.ts
@@ -56,6 +56,8 @@ export type AuthMiddlewares = {
 
 export type QueryArrayFormat = "brackets" | "comma" | "repeat"
 
+export type QueryArrayFormats = readonly QueryArrayFormat[]
+
 export interface SetupParams<
   AuthMW extends AuthMiddlewares = AuthMiddlewares,
   GlobalMW extends Middleware<any, any>[] = any[]
@@ -75,7 +77,7 @@ export interface SetupParams<
   securitySchemas?: Record<string, SecuritySchemeObject>
   globalSchemas?: Record<string, z.ZodTypeAny>
 
-  supportedArrayFormats?: QueryArrayFormat[]
+  supportedArrayFormats?: QueryArrayFormats
 }
 
 const defaultMiddlewareMap = {

--- a/packages/nextlove/src/with-route-spec/index.ts
+++ b/packages/nextlove/src/with-route-spec/index.ts
@@ -3,7 +3,7 @@ import { withExceptionHandling } from "../nextjs-exception-middleware"
 import wrappers, { Middleware } from "../wrappers"
 import {
   CreateWithRouteSpecFunction,
-  QueryArrayFormat,
+  QueryArrayFormats,
   RouteSpec,
 } from "../types"
 import withMethods, { HTTPMethods } from "./middlewares/with-methods"
@@ -46,7 +46,7 @@ export const checkRouteSpec = <
   ? `your route spec is underspecified, add "as const"`
   : Spec => spec as any
 
-export const DEFAULT_ARRAY_FORMATS: QueryArrayFormat[] = [
+export const DEFAULT_ARRAY_FORMATS: QueryArrayFormats = [
   "brackets",
   "comma",
   "repeat",

--- a/packages/nextlove/src/with-route-spec/middlewares/with-validation.ts
+++ b/packages/nextlove/src/with-route-spec/middlewares/with-validation.ts
@@ -6,7 +6,7 @@ import {
   BadRequestException,
   InternalServerErrorException,
 } from "../../nextjs-exception-middleware"
-import { QueryArrayFormat } from "../../types"
+import { QueryArrayFormats } from "../../types"
 import { DEFAULT_ARRAY_FORMATS } from ".."
 
 const getZodObjectSchemaFromZodEffectSchema = (
@@ -82,7 +82,7 @@ const isZodSchemaBoolean = (schema: z.ZodTypeAny) => {
 const parseQueryParams = (
   schema: z.ZodTypeAny,
   input: Record<string, unknown>,
-  supportedArrayFormats: QueryArrayFormat[]
+  supportedArrayFormats: QueryArrayFormats
 ) => {
   const parsed_input = Object.assign({}, input)
   const obj_schema = tryGetZodSchemaAsObject(schema)
@@ -134,7 +134,7 @@ const parseQueryParams = (
 const validateQueryParams = (
   inputUrl: string,
   schema: z.ZodTypeAny,
-  supportedArrayFormats: QueryArrayFormat[]
+  supportedArrayFormats: QueryArrayFormats
 ) => {
   const url = new URL(inputUrl, "http://dummy.com")
 
@@ -191,7 +191,7 @@ export interface RequestInput<
   jsonResponse?: JsonResponse
   shouldValidateResponses?: boolean
   shouldValidateGetRequestBody?: boolean
-  supportedArrayFormats?: QueryArrayFormat[]
+  supportedArrayFormats?: QueryArrayFormats
 }
 
 const zodIssueToString = (issue: z.ZodIssue) => {


### PR DESCRIPTION
This is causing problems since we often have to call `createWithRouteSpec` as a const object, which makes the list of array formats `readonly`, which prevents passing as a normal array.