### PR TITLE
feat: Allow including OpenAPI excluded routes in route type generation

### DIFF
--- a/packages/nextlove/src/generators/generate-route-types/index.ts
+++ b/packages/nextlove/src/generators/generate-route-types/index.ts
@@ -14,6 +14,11 @@ interface GenerateRouteTypesOpts {
    * If provided, only routes that return true will be included in the generated types.
    */
   filterRoutes?: (route: string) => boolean
+  /**
+   * By default, routes that have `excludeFromOpenApi` set to true will be excluded from the generated types.
+   * Set this to true to include them.
+   */
+  includeOpenApiExcludedRoutes?: boolean
 }
 
 export const generateRouteTypes = async (opts: GenerateRouteTypesOpts) => {

--- a/packages/nextlove/src/generators/lib/parse-routes-in-package.ts
+++ b/packages/nextlove/src/generators/lib/parse-routes-in-package.ts
@@ -14,6 +14,7 @@ export const parseRoutesInPackage = async (opts: {
   pathGlob?: string
   apiPrefix?: string
   mapFilePathToHTTPRoute?: (file_path: string) => string
+  includeOpenApiExcludedRoutes?: boolean
 }): Promise<Map<string, RouteInfo>> => {
   const chalk = (await import("chalk")).default
   const globby = (await import("globby")).globby
@@ -37,7 +38,10 @@ export const parseRoutesInPackage = async (opts: {
       const { default: routeFn } = await require(path.resolve(p))
 
       if (routeFn) {
-        if (routeFn._routeSpec?.excludeFromOpenApi) {
+        if (
+          routeFn._routeSpec?.excludeFromOpenApi &&
+          !opts.includeOpenApiExcludedRoutes
+        ) {
           console.log(
             chalk.gray(
               `Ignoring "${p} because it was excluded from OpenAPI generation"`


### PR DESCRIPTION
New version of nextlove breaks types in Seam Connect because the internal variant of route type generation needs to include all routes.
