### PR TITLE
expose onMultipleAuthMiddlewareFailures binding on route level

### DIFF
--- a/apps/example-todo-app/pages/api/todo/multiple-auth-errors-handled-by-route.ts
+++ b/apps/example-todo-app/pages/api/todo/multiple-auth-errors-handled-by-route.ts
@@ -1,0 +1,22 @@
+import { UnauthorizedException } from "nextlove"
+import { withRouteSpec } from "lib/middlewares"
+
+export default withRouteSpec({
+  methods: ["GET"],
+  auth: ["auth_token", "user_session"],
+  onMultipleAuthMiddlewareFailures(errors: Error[]) {
+    const unauthorizedErrors = errors.filter(
+      (error) =>
+        "metadata" in error &&
+        typeof error.metadata === "object" &&
+        "type" in error.metadata &&
+        error.metadata.type === "unauthorized"
+    )
+    throw new UnauthorizedException({
+      type: "multiple_unauthorized",
+      message: `Received ${unauthorizedErrors.length} unauthorized errors`,
+    })
+  },
+} as const)(async (req, res) => {
+  return res.status(200).send(undefined)
+})

--- a/apps/example-todo-app/tests/api/todo/multiple-auth-errors-handled-by-route.test.ts
+++ b/apps/example-todo-app/tests/api/todo/multiple-auth-errors-handled-by-route.test.ts
@@ -1,0 +1,18 @@
+import test from "ava"
+import getTestServer from "tests/fixtures/get-test-server"
+import { AxiosError } from "axios"
+
+test("GET /todo/multiple-auth-errors-handled-by-route", async (t) => {
+  const { axios } = await getTestServer(t)
+
+  return axios
+    .get("/todo/multiple-auth-errors-handled-by-route")
+    .catch((error: AxiosError) => {
+      t.like(error.response, {
+        error: {
+          message: "Received 2 unauthorized errors",
+          type: "multiple_unauthorized",
+        },
+      })
+    })
+})

--- a/packages/nextlove/src/types/index.ts
+++ b/packages/nextlove/src/types/index.ts
@@ -40,6 +40,8 @@ export interface RouteSpec<
    * add x-fern-sdk-return-value to the openapi spec, useful when you want to return only a subset of the response
    */
   sdkReturnValue?: string | string[]
+
+  onMultipleAuthMiddlewareFailures?: (errors: unknown[]) => void
 }
 
 export type MiddlewareChainOutput<

--- a/packages/nextlove/src/with-route-spec/index.ts
+++ b/packages/nextlove/src/with-route-spec/index.ts
@@ -101,6 +101,10 @@ export const createWithRouteSpec: CreateWithRouteSpecFunction = ((
           let errors: unknown[] = []
           let didAuthMiddlewareThrow = true
 
+          const handleMultipleAuthMiddlewareFailures =
+            spec.onMultipleAuthMiddlewareFailures ??
+            onMultipleAuthMiddlewareFailures
+
           for (const middleware of authMiddlewares) {
             try {
               return await middleware((...args) => {
@@ -118,8 +122,8 @@ export const createWithRouteSpec: CreateWithRouteSpecFunction = ((
             }
           }
 
-          if (onMultipleAuthMiddlewareFailures && didAuthMiddlewareThrow) {
-            onMultipleAuthMiddlewareFailures(errors)
+          if (handleMultipleAuthMiddlewareFailures && didAuthMiddlewareThrow) {
+            handleMultipleAuthMiddlewareFailures(errors)
           }
 
           throw errors[errors.length - 1]

--- a/packages/nextlove/tests/with-route-spec/basic.test.ts
+++ b/packages/nextlove/tests/with-route-spec/basic.test.ts
@@ -1,0 +1,39 @@
+import test from "ava"
+import { createWithRouteSpec } from "../../src/with-route-spec"
+
+test("route-level onMultipleAuthMiddlewareFailures spec takes precedent", async (t) => {
+  let globalWasCalled = false
+  let routeWasCalled = false
+  const globalErrorHandler = () => void (globalWasCalled = true)
+  const routeErrorHandler = () => void (routeWasCalled = true)
+  const withRouteSpec = createWithRouteSpec({
+    apiName: "test",
+    productionServerUrl: "https://seam.com",
+    globalMiddlewares: [],
+    authMiddlewareMap: {
+      test: () => {
+        throw new Error("test")
+      },
+    },
+    onMultipleAuthMiddlewareFailures: globalErrorHandler,
+  })
+  const route = withRouteSpec({
+    methods: ["POST"],
+    auth: "test",
+    onMultipleAuthMiddlewareFailures: routeErrorHandler,
+    handler: () => void 0,
+  })
+  await t.notThrowsAsync(async () =>
+    route(async () => void 0)(
+      {} as any,
+      {
+        status() {
+          return { json() {} }
+        },
+      } as any
+    )
+  )
+
+  t.is(globalWasCalled, false)
+  t.is(routeWasCalled, true)
+})

--- a/packages/nextlove/tests/with-route-spec/basic.test.ts
+++ b/packages/nextlove/tests/with-route-spec/basic.test.ts
@@ -34,6 +34,6 @@ test("route-level onMultipleAuthMiddlewareFailures spec takes precedent", async 
     )
   )
 
-  t.is(globalWasCalled, false)
-  t.is(routeWasCalled, true)
+  t.false(globalWasCalled)
+  t.true(routeWasCalled)
 })


### PR DESCRIPTION
not sure if this is needed, definitely feels like a bit of an early optimization. I felt like we might want the ability to override the `onMultipleAuthMiddlewareFailures` binding declared in setup params at the route level as we continue to add support for multiple auth handlers for a route. this will allow us to override the "global" handler as the route configuration will take precedence. 