### PR TITLE
Enhance OpenAPI Spec Generation for Nullable Union Types in Record Properties

### DIFF
--- a/apps/example-todo-app/pages/api/todo/add.ts
+++ b/apps/example-todo-app/pages/api/todo/add.ts
@@ -20,6 +20,7 @@ export const jsonBody = z.object({
     ---
     This is an unused, deprecated field.
   `),
+  description: z.string().nullable(),
 })
 
 export const route_spec = checkRouteSpec({

--- a/apps/example-todo-app/pages/api/todo/add.ts
+++ b/apps/example-todo-app/pages/api/todo/add.ts
@@ -21,6 +21,10 @@ export const jsonBody = z.object({
     This is an unused, deprecated field.
   `),
   description: z.string().nullable().optional(),
+  metadata: z.record(
+    z.string().max(40),
+    z.union([z.string().max(500), z.boolean(), z.null()])
+  ),
 })
 
 export const route_spec = checkRouteSpec({

--- a/apps/example-todo-app/pages/api/todo/add.ts
+++ b/apps/example-todo-app/pages/api/todo/add.ts
@@ -21,10 +21,12 @@ export const jsonBody = z.object({
     This is an unused, deprecated field.
   `),
   description: z.string().nullable().optional(),
-  metadata: z.record(
-    z.string().max(40),
-    z.union([z.string().max(500), z.boolean(), z.null()])
-  ),
+  metadata: z
+    .record(
+      z.string().max(40),
+      z.union([z.string().max(500), z.boolean(), z.null()])
+    )
+    .optional(),
 })
 
 export const route_spec = checkRouteSpec({

--- a/apps/example-todo-app/pages/api/todo/add.ts
+++ b/apps/example-todo-app/pages/api/todo/add.ts
@@ -20,7 +20,7 @@ export const jsonBody = z.object({
     ---
     This is an unused, deprecated field.
   `),
-  description: z.string().nullable(),
+  description: z.string().nullable().optional(),
 })
 
 export const route_spec = checkRouteSpec({

--- a/apps/example-todo-app/tests/openapi-generation/openapi-generation.test.ts
+++ b/apps/example-todo-app/tests/openapi-generation/openapi-generation.test.ts
@@ -27,7 +27,7 @@ test("generateOpenAPI correctly parses nullable params", async (t) => {
   t.true(descriptionParam.nullable)
 })
 
-test("generateOpenAPI excludes null type from union, marking the property as a whole as nullable instead", async (t) => {
+test("generateOpenAPI marks properties with null unions as nullable", async (t) => {
   const openapiJson = JSON.parse(
     await generateOpenAPI({
       packageDir: ".",

--- a/apps/example-todo-app/tests/openapi-generation/openapi-generation.test.ts
+++ b/apps/example-todo-app/tests/openapi-generation/openapi-generation.test.ts
@@ -10,7 +10,7 @@ test("should generate openapi with expected properties", async (t) => {
   t.deepEqual(typeof openapiJson, "object")
 })
 
-test("nullable param is correctly parsed", async (t) => {
+test("generateOpenAPI correctly parses nullable params", async (t) => {
   const openapiJson = JSON.parse(
     await generateOpenAPI({
       packageDir: ".",
@@ -25,4 +25,25 @@ test("nullable param is correctly parsed", async (t) => {
   t.truthy(descriptionParam)
   t.is(descriptionParam.type, "string")
   t.true(descriptionParam.nullable)
+})
+
+test("generateOpenAPI excludes null type from union, marking the property as a whole as nullable instead", async (t) => {
+  const openapiJson = JSON.parse(
+    await generateOpenAPI({
+      packageDir: ".",
+    })
+  )
+
+  const routeSpec = openapiJson.paths["/api/todo/add"].post
+  const metadataParam =
+    routeSpec.requestBody.content["application/json"].schema.properties.metadata
+
+  t.truthy(metadataParam)
+  t.is(metadataParam.type, "object")
+  t.true(metadataParam.additionalProperties.nullable)
+  t.true(
+    metadataParam.additionalProperties.oneOf.every(
+      (schema) => schema.type !== "null"
+    )
+  )
 })

--- a/apps/example-todo-app/tests/openapi-generation/openapi-generation.test.ts
+++ b/apps/example-todo-app/tests/openapi-generation/openapi-generation.test.ts
@@ -9,3 +9,20 @@ test("should generate openapi with expected properties", async (t) => {
   )
   t.deepEqual(typeof openapiJson, "object")
 })
+
+test("nullable param is correctly parsed", async (t) => {
+  const openapiJson = JSON.parse(
+    await generateOpenAPI({
+      packageDir: ".",
+    })
+  )
+
+  const routeSpec = openapiJson.paths["/api/todo/add"].post
+  const descriptionParam =
+    routeSpec.requestBody.content["application/json"].schema.properties
+      .description
+
+  t.truthy(descriptionParam)
+  t.is(descriptionParam.type, "string")
+  t.true(descriptionParam.nullable)
+})

--- a/packages/nextlove/src/generators/lib/zod-openapi.ts
+++ b/packages/nextlove/src/generators/lib/zod-openapi.ts
@@ -368,7 +368,7 @@ function parseNullable({
 }: ParsingArgs<z.ZodNullable<OpenApiZodAny>>): SchemaObject {
   const schema = generateSchema(zodRef.unwrap(), useOutput)
   return merge(
-    { ...schema, type: [schema.type, "null"] as SchemaObjectType[] },
+    { ...schema, type: schema.type, nullable: true },
     parseDescription(zodRef),
     ...schemas
   )

--- a/packages/nextlove/src/generators/lib/zod-openapi.ts
+++ b/packages/nextlove/src/generators/lib/zod-openapi.ts
@@ -495,9 +495,17 @@ function parseUnion({
     }
   }
 
+  const isNullable = contents.some(
+    (content) => content._def.typeName === "ZodNull"
+  )
+  const nonNullContents = contents.filter(
+    (content) => content._def.typeName !== "ZodNull"
+  )
+
   return merge(
     {
-      oneOf: contents.map((schema) => generateSchema(schema, useOutput)),
+      oneOf: nonNullContents.map((schema) => generateSchema(schema, useOutput)),
+      ...(isNullable ? { nullable: true } : {}),
     },
     parseDescription(zodRef),
     ...schemas


### PR DESCRIPTION
This should fix a validation error that we get on seam-connect:
![image](https://github.com/seamapi/nextlove/assets/84702959/6db71bbb-fed2-41b3-b42e-cfe6c536e111)

`{ "type": "null" }` is not valid as a `oneOf` option, like here:
![image](https://github.com/seamapi/nextlove/assets/84702959/e7139f0b-0cde-4daf-a851-752c9bdc665a)

Instead, this PR makes so that `{ "nullable": true }` is set
![image](https://github.com/seamapi/nextlove/assets/84702959/bfe847e7-0edc-46dd-916f-c8b59e68698a)
