### PR TITLE
OpenAPI generation: `null` params should be flagged with `nullable`

### DIFF
--- a/apps/example-todo-app/pages/api/todo/add.ts
+++ b/apps/example-todo-app/pages/api/todo/add.ts
@@ -27,6 +27,7 @@ export const jsonBody = z.object({
       z.union([z.string().max(500), z.boolean(), z.null()])
     )
     .optional(),
+  testNull: z.null().optional(),
 })
 
 export const route_spec = checkRouteSpec({

--- a/apps/example-todo-app/tests/openapi-generation/openapi-generation.test.ts
+++ b/apps/example-todo-app/tests/openapi-generation/openapi-generation.test.ts
@@ -47,3 +47,19 @@ test("generateOpenAPI marks properties with null unions as nullable", async (t) 
     )
   )
 })
+
+test("generateOpenAPI marks null params with nullable flag", async (t) => {
+  const openapiJson = JSON.parse(
+    await generateOpenAPI({
+      packageDir: ".",
+    })
+  )
+
+  const routeSpec = openapiJson.paths["/api/todo/add"].post
+  const testNullParam =
+    routeSpec.requestBody.content["application/json"].schema.properties.testNull
+
+  t.truthy(testNullParam)
+  t.falsy(testNullParam.type)
+  t.true(testNullParam.nullable)
+})

--- a/packages/nextlove/src/generators/lib/zod-openapi.ts
+++ b/packages/nextlove/src/generators/lib/zod-openapi.ts
@@ -342,7 +342,7 @@ function parseDate({ zodRef, schemas }: ParsingArgs<z.ZodDate>): SchemaObject {
 function parseNull({ zodRef, schemas }: ParsingArgs<z.ZodNull>): SchemaObject {
   return merge(
     {
-      type: "null" as SchemaObjectType,
+      nullable: true,
     },
     parseDescription(zodRef),
     ...schemas


### PR DESCRIPTION
OpenAPI 3.0 does not have an explicit `null` type as in JSON Schema. This PR replaces it with `nullable: true` which is supported.