### PR TITLE
Deprecate `sdkReturnValue` in favour of `response_key` in the front matter of the `description`

### DIFF
--- a/apps/example-todo-app/pages/api/todo/add.ts
+++ b/apps/example-todo-app/pages/api/todo/add.ts
@@ -44,6 +44,7 @@ export const route_spec = checkRouteSpec({
     ---
     This endpoint allows you to add a new todo item to the list. Deprecated.
   `,
+  sdkReturnValue: "foo",
 })
 
 export default withRouteSpec(route_spec)(async (req, res) => {

--- a/apps/example-todo-app/pages/api/todo/add.ts
+++ b/apps/example-todo-app/pages/api/todo/add.ts
@@ -17,6 +17,7 @@ export const jsonBody = z.object({
     ---
     title: Unused
     deprecated: yes, because it's deprecated.
+    snake_case: Snake case property
     ---
     This is an unused, deprecated field.
   `),

--- a/apps/example-todo-app/pages/api/todo/add.ts
+++ b/apps/example-todo-app/pages/api/todo/add.ts
@@ -40,6 +40,7 @@ export const route_spec = checkRouteSpec({
   description: `
     ---
     deprecated: Use foobar instead.
+    response_key: foobar
     ---
     This endpoint allows you to add a new todo item to the list. Deprecated.
   `,

--- a/apps/example-todo-app/tests/openapi-generation/openapi-generation.test.ts
+++ b/apps/example-todo-app/tests/openapi-generation/openapi-generation.test.ts
@@ -79,4 +79,6 @@ test("generateOpenAPI correctly parses description with front matter", async (t)
     "This endpoint allows you to add a new todo item to the list. Deprecated."
   )
   t.is(routeSpec.deprecated, "Use foobar instead.")
+  t.is(routeSpec["x-fern-sdk-return-value"], "foobar")
+  t.is(routeSpec.response_key, "foobar")
 })

--- a/apps/example-todo-app/tests/openapi-generation/openapi-generation.test.ts
+++ b/apps/example-todo-app/tests/openapi-generation/openapi-generation.test.ts
@@ -64,7 +64,7 @@ test("generateOpenAPI marks null params with nullable flag", async (t) => {
   t.true(testNullParam.nullable)
 })
 
-test("generateOpenAPI correctly parses description with front matter", async (t) => {
+test("generateOpenAPI correctly parses endpoint description with front matter and prefixes custom properties with 'x-'", async (t) => {
   const openapiJson = JSON.parse(
     await generateOpenAPI({
       packageDir: ".",
@@ -75,10 +75,28 @@ test("generateOpenAPI correctly parses description with front matter", async (t)
 
   t.truthy(routeSpec.description)
   t.is(
-    routeSpec.description.trim(),
+    routeSpec.description,
     "This endpoint allows you to add a new todo item to the list. Deprecated."
   )
   t.is(routeSpec["x-deprecated"], "Use foobar instead.")
   t.is(routeSpec["x-fern-sdk-return-value"], "foobar")
   t.is(routeSpec["x-response-key"], "foobar")
+})
+
+test("generateOpenAPI correctly parses property description with front matter and prefixes custom properties with 'x-'", async (t) => {
+  const openapiJson = JSON.parse(
+    await generateOpenAPI({
+      packageDir: ".",
+    })
+  )
+
+  const routeSpec = openapiJson.paths["/api/todo/add"].post
+  const testUnusedParam =
+    routeSpec.requestBody.content["application/json"].schema.properties.unused
+
+  t.true(testUnusedParam.deprecated)
+  t.is(testUnusedParam["x-title"], "Unused")
+  t.is(testUnusedParam["x-deprecated"], "yes, because it's deprecated.")
+  // snake case is correctly dashified
+  t.is(testUnusedParam["x-snake-case"], "Snake case property")
 })

--- a/apps/example-todo-app/tests/openapi-generation/openapi-generation.test.ts
+++ b/apps/example-todo-app/tests/openapi-generation/openapi-generation.test.ts
@@ -78,7 +78,7 @@ test("generateOpenAPI correctly parses description with front matter", async (t)
     routeSpec.description.trim(),
     "This endpoint allows you to add a new todo item to the list. Deprecated."
   )
-  t.is(routeSpec['x-deprecated'], "Use foobar instead.")
+  t.is(routeSpec["x-deprecated"], "Use foobar instead.")
   t.is(routeSpec["x-fern-sdk-return-value"], "foobar")
   t.is(routeSpec["x-response-key"], "foobar")
 })

--- a/apps/example-todo-app/tests/openapi-generation/openapi-generation.test.ts
+++ b/apps/example-todo-app/tests/openapi-generation/openapi-generation.test.ts
@@ -78,7 +78,7 @@ test("generateOpenAPI correctly parses description with front matter", async (t)
     routeSpec.description.trim(),
     "This endpoint allows you to add a new todo item to the list. Deprecated."
   )
-  t.is(routeSpec.deprecated, "Use foobar instead.")
+  t.is(routeSpec['x-deprecated'], "Use foobar instead.")
   t.is(routeSpec["x-fern-sdk-return-value"], "foobar")
-  t.is(routeSpec.response_key, "foobar")
+  t.is(routeSpec["x-response-key"], "foobar")
 })

--- a/packages/nextlove/src/generators/generate-openapi/index.ts
+++ b/packages/nextlove/src/generators/generate-openapi/index.ts
@@ -12,6 +12,7 @@ import { embedSchemaReferences } from "./embed-schema-references"
 import { mapMethodsToFernSdkMetadata } from "./fern-sdk-utils"
 import { parseFrontMatter, testFrontMatter } from "../lib/front-matter"
 import dedent from "dedent"
+import { prefixKeysWithX } from "../utils/prefix-keys-with-x"
 
 function replaceFirstCharToLowercase(str: string) {
   if (str.length === 0) {
@@ -210,9 +211,15 @@ export async function generateOpenAPI(opts: GenerateOpenAPIOpts) {
       }
     }
 
+    const formattedDescriptionMetadata = Object.fromEntries(
+      Object.entries(prefixKeysWithX(descriptionMetadata)).map(
+        ([key, value]) => [key.replace(/_/g, "-"), value]
+      )
+    )
+
     const route: OperationObject = {
       ...routeSpec.openApiMetadata,
-      ...descriptionMetadata,
+      ...formattedDescriptionMetadata,
       summary: routePath,
       ...(description && { description }),
       responses: {

--- a/packages/nextlove/src/generators/generate-openapi/index.ts
+++ b/packages/nextlove/src/generators/generate-openapi/index.ts
@@ -13,6 +13,7 @@ import { mapMethodsToFernSdkMetadata } from "./fern-sdk-utils"
 import { parseFrontMatter, testFrontMatter } from "../lib/front-matter"
 import dedent from "dedent"
 import { prefixKeysWithX } from "../utils/prefix-keys-with-x"
+import { dashifyObjectKeys } from "../utils/dashify-object-keys"
 
 function replaceFirstCharToLowercase(str: string) {
   if (str.length === 0) {
@@ -211,10 +212,8 @@ export async function generateOpenAPI(opts: GenerateOpenAPIOpts) {
       }
     }
 
-    const formattedDescriptionMetadata = Object.fromEntries(
-      Object.entries(prefixKeysWithX(descriptionMetadata)).map(
-        ([key, value]) => [key.replace(/_/g, "-"), value]
-      )
+    const formattedDescriptionMetadata = prefixKeysWithX(
+      dashifyObjectKeys(descriptionMetadata)
     )
 
     const route: OperationObject = {

--- a/packages/nextlove/src/generators/generate-openapi/index.ts
+++ b/packages/nextlove/src/generators/generate-openapi/index.ts
@@ -193,14 +193,17 @@ export async function generateOpenAPI(opts: GenerateOpenAPIOpts) {
     }
 
     let description = routeSpec.description
-    let additionalMetadata = {}
+    let descriptionMetadata: {
+      response_key?: string
+      [key: string]: any
+    } = {}
 
     if (description) {
       const trimmedDescription = dedent(description).trim()
 
       if (testFrontMatter(trimmedDescription)) {
         const { attributes, body } = parseFrontMatter(trimmedDescription)
-        additionalMetadata = attributes
+        descriptionMetadata = attributes
         description = body.trim()
       } else {
         description = trimmedDescription
@@ -209,7 +212,7 @@ export async function generateOpenAPI(opts: GenerateOpenAPIOpts) {
 
     const route: OperationObject = {
       ...routeSpec.openApiMetadata,
-      ...additionalMetadata,
+      ...descriptionMetadata,
       summary: routePath,
       ...(description && { description }),
       responses: {
@@ -304,7 +307,8 @@ export async function generateOpenAPI(opts: GenerateOpenAPIOpts) {
     const methodsMappedToFernSdkMetadata = await mapMethodsToFernSdkMetadata({
       methods,
       path: routePath,
-      sdkReturnValue: routeSpec.sdkReturnValue,
+      sdkReturnValue:
+        descriptionMetadata?.response_key ?? routeSpec.sdkReturnValue,
     })
 
     // Some routes accept multiple methods

--- a/packages/nextlove/src/generators/generate-openapi/index.ts
+++ b/packages/nextlove/src/generators/generate-openapi/index.ts
@@ -12,7 +12,7 @@ import { embedSchemaReferences } from "./embed-schema-references"
 import { mapMethodsToFernSdkMetadata } from "./fern-sdk-utils"
 import { parseFrontMatter, testFrontMatter } from "../lib/front-matter"
 import dedent from "dedent"
-import { prefixKeysWithX } from "../utils/prefix-keys-with-x"
+import { prefixObjectKeysWithX } from "../utils/prefix-object-keys-with-x"
 import { dashifyObjectKeys } from "../utils/dashify-object-keys"
 
 function replaceFirstCharToLowercase(str: string) {
@@ -212,7 +212,7 @@ export async function generateOpenAPI(opts: GenerateOpenAPIOpts) {
       }
     }
 
-    const formattedDescriptionMetadata = prefixKeysWithX(
+    const formattedDescriptionMetadata = prefixObjectKeysWithX(
       dashifyObjectKeys(descriptionMetadata)
     )
 

--- a/packages/nextlove/src/generators/lib/zod-openapi.ts
+++ b/packages/nextlove/src/generators/lib/zod-openapi.ts
@@ -82,14 +82,16 @@ function parseDescription(zodRef: OpenApiZodAny): SchemaObject {
   if (!testFrontMatter(trimmedDescription))
     return { description: zodRef.description }
   const { attributes, body } = parseFrontMatter(trimmedDescription)
-  let output: SchemaObject = {}
+  const output: SchemaObject = {}
   if (body.trim()) output.description = body.trim()
   if (typeof attributes === "object" && attributes !== null) {
     if ("deprecated" in attributes && attributes.deprecated) {
       output.deprecated = true
     }
 
-    output = prefixKeysWithX(output)
+    Object.entries(prefixKeysWithX(attributes)).forEach(([key, value]) => {
+      output[key] = value
+    })
   }
 
   return output

--- a/packages/nextlove/src/generators/lib/zod-openapi.ts
+++ b/packages/nextlove/src/generators/lib/zod-openapi.ts
@@ -31,7 +31,7 @@ import merge from "ts-deepmerge"
 import { AnyZodObject, z, ZodTypeAny } from "zod"
 import { parseFrontMatter, testFrontMatter } from "./front-matter"
 import dedent from "dedent"
-import { prefixKeysWithX } from "../utils/prefix-keys-with-x"
+import { prefixObjectKeysWithX } from "../utils/prefix-object-keys-with-x"
 import { dashifyObjectKeys } from "../utils/dashify-object-keys"
 
 type AnatineSchemaObject = SchemaObject & { hideDefinitions?: string[] }
@@ -90,11 +90,11 @@ function parseDescription(zodRef: OpenApiZodAny): SchemaObject {
       output.deprecated = true
     }
 
-    Object.entries(prefixKeysWithX(dashifyObjectKeys(attributes))).forEach(
-      ([key, value]) => {
-        output[key] = value
-      }
-    )
+    Object.entries(
+      prefixObjectKeysWithX(dashifyObjectKeys(attributes))
+    ).forEach(([key, value]) => {
+      output[key] = value
+    })
   }
 
   return output

--- a/packages/nextlove/src/generators/lib/zod-openapi.ts
+++ b/packages/nextlove/src/generators/lib/zod-openapi.ts
@@ -32,6 +32,7 @@ import { AnyZodObject, z, ZodTypeAny } from "zod"
 import { parseFrontMatter, testFrontMatter } from "./front-matter"
 import dedent from "dedent"
 import { prefixKeysWithX } from "../utils/prefix-keys-with-x"
+import { dashifyObjectKeys } from "../utils/dashify-object-keys"
 
 type AnatineSchemaObject = SchemaObject & { hideDefinitions?: string[] }
 
@@ -89,9 +90,11 @@ function parseDescription(zodRef: OpenApiZodAny): SchemaObject {
       output.deprecated = true
     }
 
-    Object.entries(prefixKeysWithX(attributes)).forEach(([key, value]) => {
-      output[key] = value
-    })
+    Object.entries(prefixKeysWithX(dashifyObjectKeys(attributes))).forEach(
+      ([key, value]) => {
+        output[key] = value
+      }
+    )
   }
 
   return output

--- a/packages/nextlove/src/generators/lib/zod-openapi.ts
+++ b/packages/nextlove/src/generators/lib/zod-openapi.ts
@@ -31,6 +31,7 @@ import merge from "ts-deepmerge"
 import { AnyZodObject, z, ZodTypeAny } from "zod"
 import { parseFrontMatter, testFrontMatter } from "./front-matter"
 import dedent from "dedent"
+import { prefixKeysWithX } from "../utils/prefix-keys-with-x"
 
 type AnatineSchemaObject = SchemaObject & { hideDefinitions?: string[] }
 
@@ -81,16 +82,16 @@ function parseDescription(zodRef: OpenApiZodAny): SchemaObject {
   if (!testFrontMatter(trimmedDescription))
     return { description: zodRef.description }
   const { attributes, body } = parseFrontMatter(trimmedDescription)
-  const output: SchemaObject = {}
+  let output: SchemaObject = {}
   if (body.trim()) output.description = body.trim()
   if (typeof attributes === "object" && attributes !== null) {
     if ("deprecated" in attributes && attributes.deprecated) {
       output.deprecated = true
     }
-    for (const [key, value] of Object.entries(attributes)) {
-      output[`x-${key}`] = value
-    }
+
+    output = prefixKeysWithX(output)
   }
+
   return output
 }
 

--- a/packages/nextlove/src/generators/utils/dashify-object-keys.ts
+++ b/packages/nextlove/src/generators/utils/dashify-object-keys.ts
@@ -1,0 +1,13 @@
+type SnakeToDash<T> = {
+  [K in keyof T as K extends string ? SnakeToDashString<K> : K]: T[K]
+}
+
+type SnakeToDashString<S extends string> = S extends `${infer T}_${infer U}`
+  ? `${T}-${SnakeToDashString<U>}`
+  : S
+
+export function dashifyObjectKeys<T extends object>(obj: T): SnakeToDash<T> {
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => [key.replace(/_/g, "-"), value])
+  ) as SnakeToDash<T>
+}

--- a/packages/nextlove/src/generators/utils/prefix-keys-with-x.ts
+++ b/packages/nextlove/src/generators/utils/prefix-keys-with-x.ts
@@ -1,0 +1,9 @@
+type PrefixedObject<T> = {
+  [K in keyof T as `x-${string & K}`]: T[K]
+}
+
+export function prefixKeysWithX<T extends object>(obj: T): PrefixedObject<T> {
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => [`x-${key}`, value])
+  ) as PrefixedObject<T>
+}

--- a/packages/nextlove/src/generators/utils/prefix-object-keys-with-x.ts
+++ b/packages/nextlove/src/generators/utils/prefix-object-keys-with-x.ts
@@ -2,7 +2,9 @@ type PrefixedObject<T> = {
   [K in keyof T as `x-${string & K}`]: T[K]
 }
 
-export function prefixKeysWithX<T extends object>(obj: T): PrefixedObject<T> {
+export function prefixObjectKeysWithX<T extends object>(
+  obj: T
+): PrefixedObject<T> {
   return Object.fromEntries(
     Object.entries(obj).map(([key, value]) => [`x-${key}`, value])
   ) as PrefixedObject<T>

--- a/packages/nextlove/src/types/index.ts
+++ b/packages/nextlove/src/types/index.ts
@@ -38,7 +38,7 @@ export interface RouteSpec<
   jsonResponse?: JsonResponse
   formData?: FormData
   /**
-   * add x-fern-sdk-return-value to the openapi spec, useful when you want to return only a subset of the response
+   * @deprecated Use `response_key` in the front matter of the `description` instead.
    */
   sdkReturnValue?: string | string[]
 


### PR DESCRIPTION
wrt https://github.com/seamapi/nextlove/issues/143

- **Deprecate sdkReturnValue in favour of front matter response_key**
- **Test response_key**
- **Custom front matter `description` properties should be prefixed with `x-` and in dash style `x-my-prop`**
