### PR TITLE
fix: allow generating GET and POST openapi spec

### DIFF
--- a/.github/workflows/npm-lint.yml
+++ b/.github/workflows/npm-lint.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 16
           cache: "yarn"

--- a/.github/workflows/npm-lint.yml
+++ b/.github/workflows/npm-lint.yml
@@ -4,7 +4,7 @@ jobs:
   npm_test:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     name: Run NPM lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/npm-semantic-release.yml
+++ b/.github/workflows/npm-semantic-release.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: "16.x"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/npm-semantic-release.yml
+++ b/.github/workflows/npm-semantic-release.yml
@@ -7,7 +7,7 @@ jobs:
   publish:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     name: Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 16
           cache: "yarn"

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -4,7 +4,7 @@ jobs:
   npm_test:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     name: Run NPM Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/apps/example-todo-app/pages/api/todo/list.ts
+++ b/apps/example-todo-app/pages/api/todo/list.ts
@@ -8,7 +8,7 @@ export const commonParams = z.object({
 })
 
 export const route_spec = checkRouteSpec({
-  methods: ["GET"],
+  methods: ["GET", "POST"],
   auth: "auth_token",
   commonParams,
   jsonResponse: z.object({

--- a/packages/nextlove/bin.js
+++ b/packages/nextlove/bin.js
@@ -64,7 +64,9 @@ if (argv._[0] === "generate-openapi") {
   if (!argv["packageDir"]) throw new Error("Missing --packageDir")
 
   if (argv["allowed-import-patterns"]) {
-    argv.allowedImportPatterns = Array.isArray(argv["allowed-import-patterns"]) ? argv["allowed-import-patterns"] : [argv["allowed-import-patterns"]]
+    argv.allowedImportPatterns = Array.isArray(argv["allowed-import-patterns"])
+      ? argv["allowed-import-patterns"]
+      : [argv["allowed-import-patterns"]]
   }
 
   require("./dist/generators")


### PR DESCRIPTION
Closes https://github.com/seamapi/nextlove/pull/115

Pretty much the title, previously generating the OpenAPI json would ignore GET if POST was defined as well. Now it generates both (and DELETE too).

Main change was to remove the filter at https://github.com/seamapi/nextlove/pull/159/files#diff-3f2c0f6d81a28b504bad9f4790e395fdf0d3fd6dd3fe8848371b3499e243abd1L179

![CleanShot 2025-06-19 at 07 16 41@2x](https://github.com/user-attachments/assets/f61569fc-ba46-4c49-b72c-cfa478f494a6)

But because request body and query definitions were checked at the route level and not the method level, this resulted in the generated spec to be wrong. i.e. generating a `requestBody` for GET and not a `parameters`.

The fix was to create a loop per method, and move the body and query defs in there instead. Looks like lots of changes, but it's just moving nesting: https://github.com/seamapi/nextlove/pull/159/files#diff-3f2c0f6d81a28b504bad9f4790e395fdf0d3fd6dd3fe8848371b3499e243abd1R213

This [test](https://github.com/seamapi/nextlove/pull/159/files#diff-1817d06e0c95cd83e75b933cfa3b5ead14dadefb1505bc5dd1efced7348b824eR123) asserts that each generated method looks right 

