### PR TITLE
feat: Map ZodTuple to a fixed-length array schema

### DIFF
--- a/apps/example-todo-app/pages/api/todo/add.ts
+++ b/apps/example-todo-app/pages/api/todo/add.ts
@@ -29,6 +29,11 @@ export const jsonBody = z.object({
     )
     .optional(),
   testNull: z.null().optional(),
+  completedBetween: z
+    .tuple([z.string().datetime(), z.string().datetime()])
+    .optional(),
+  positionAndLabel: z.tuple([z.number(), z.string()]).optional(),
+  variadicTags: z.tuple([z.string()]).rest(z.string()).optional(),
   arrayDescription: z
     .array(
       z.object({}).describe(`

--- a/apps/example-todo-app/tests/openapi-generation/openapi-generation.test.ts
+++ b/apps/example-todo-app/tests/openapi-generation/openapi-generation.test.ts
@@ -168,3 +168,41 @@ test("generateOpenAPI includes GET even when POST is defined", async (t) => {
 
   t.falsy(openapiJson.paths["/api/todo/list"].post.parameters)
 })
+
+test("generateOpenAPI describes tuples as fixed-length arrays", async (t) => {
+  const openapiJson = JSON.parse(
+    await generateOpenAPI({
+      packageDir: ".",
+    })
+  )
+
+  const { properties } =
+    openapiJson.paths["/api/todo/add"].post.requestBody.content[
+      "application/json"
+    ].schema
+
+  // Every position shares one schema, so items does not need a oneOf.
+  t.like(properties.completedBetween, {
+    type: "array",
+    items: { type: "string", format: "date-time" },
+    minItems: 2,
+    maxItems: 2,
+  })
+  t.falsy(properties.completedBetween.items.oneOf)
+
+  t.deepEqual(properties.positionAndLabel.type, "array")
+  t.deepEqual(properties.positionAndLabel.minItems, 2)
+  t.deepEqual(properties.positionAndLabel.maxItems, 2)
+  t.deepEqual(
+    properties.positionAndLabel.items.oneOf.map(({ type }) => type),
+    ["number", "string"]
+  )
+
+  // A rest type means there is no upper bound on the length.
+  t.like(properties.variadicTags, {
+    type: "array",
+    items: { type: "string" },
+    minItems: 1,
+  })
+  t.falsy(properties.variadicTags.maxItems)
+})

--- a/packages/nextlove/src/generators/lib/zod-openapi.ts
+++ b/packages/nextlove/src/generators/lib/zod-openapi.ts
@@ -44,6 +44,8 @@ import {
   getDefaultValue,
   getArrayConstraints,
   getRecordValueType,
+  getTupleItems,
+  getTupleRest,
   getCatchall,
   getUnknownKeys,
   getIntersectionParts,
@@ -494,6 +496,51 @@ function parseArray({
   )
 }
 
+// OpenAPI 3.0 has no positional item schemas, so a tuple becomes a
+// fixed-length array whose items accept every position's schema. `prefixItems`
+// (OpenAPI 3.1) would describe the positions exactly, but emitting it here
+// would produce specs that 3.0 tooling rejects.
+function parseTuple({
+  schemas,
+  zodRef,
+  useOutput,
+}: ParsingArgs<any>): SchemaObject {
+  const items = getTupleItems(zodRef)
+  const rest = getTupleRest(zodRef)
+
+  const itemSchemas = [...items, ...(rest == null ? [] : [rest])].map((item) =>
+    generateSchema(item, useOutput)
+  )
+  const uniqueItemSchemas = itemSchemas.filter(
+    (itemSchema, index) =>
+      itemSchemas.findIndex(
+        (otherSchema) =>
+          JSON.stringify(otherSchema) === JSON.stringify(itemSchema)
+      ) === index
+  )
+
+  const [onlyItemSchema] = uniqueItemSchemas
+
+  return mergeSchemas(
+    {
+      type: "array" as SchemaObjectType,
+      ...(uniqueItemSchemas.length === 0
+        ? {}
+        : {
+            items:
+              uniqueItemSchemas.length === 1
+                ? onlyItemSchema
+                : { oneOf: uniqueItemSchemas },
+          }),
+      minItems: items.length,
+      // A variadic tuple accepts any number of trailing rest values.
+      ...(rest == null ? { maxItems: items.length } : {}),
+    },
+    parseDescription(zodRef),
+    ...schemas
+  )
+}
+
 function parseLiteral({ schemas, zodRef }: ParsingArgs<any>): SchemaObject {
   const value = getLiteralValue(zodRef)
   return mergeSchemas(
@@ -674,10 +721,9 @@ const workerMap = {
   ZodDiscriminatedUnion: parseDiscriminatedUnion,
   ZodNever: parseNever,
   ZodBranded: parseBranded,
+  ZodTuple: parseTuple,
   // TODO Transform the rest to schemas
   ZodUndefined: catchAllParser,
-  // TODO: `prefixItems` is allowed in OpenAPI 3.1 which can be used to create tuples
-  ZodTuple: catchAllParser,
   ZodMap: catchAllParser,
   ZodFunction: catchAllParser,
   ZodLazy: catchAllParser,

--- a/packages/nextlove/src/lib/zod-compat.ts
+++ b/packages/nextlove/src/lib/zod-compat.ts
@@ -324,6 +324,14 @@ export function getTupleItems(schema: ZodTypeAny): ZodTypeAny[] {
 }
 
 /**
+ * Get the rest type of a variadic tuple, e.g. z.tuple([z.string()]).rest(z.number())
+ */
+export function getTupleRest(schema: ZodTypeAny): ZodTypeAny | undefined {
+  const def = getDef(schema)
+  return def?.rest ?? undefined
+}
+
+/**
  * Get function args and returns
  */
 export function getFunctionParts(schema: ZodTypeAny): {


### PR DESCRIPTION
Tuples fell through to `catchAllParser`, so a `z.tuple()` field emitted an empty schema with no `type`. Downstream tooling then has nothing to work with — the Seam blueprint generator skips any property whose schema lacks a type, so tuple fields silently dropped out of the API documentation:

```
The created_between property for /seam/console/v1/timelines/get will not be documented since it does not define a type.
The enforced_setpoint_range_celsius property for device.properties.sensi_metadata will not be documented since it does not define a type.
```

OpenAPI 3.0 has no positional item schemas, so a tuple becomes a fixed-length array whose `items` accept every position's schema — a single schema when the positions agree, otherwise a `oneOf`. A `.rest()` type contributes its schema and drops `maxItems`, since a variadic tuple has no upper bound. `prefixItems` would describe the positions exactly, but it is OpenAPI 3.1 only, and consumers such as `seam-connect` emit `openapi: "3.0.0"` and lint the result, so emitting it would produce specs their tooling rejects.

Generated schemas, from the three fields added to the example app's `/api/todo/add` body:

| Zod | OpenAPI |
| --- | --- |
| `z.tuple([z.string().datetime(), z.string().datetime()])` | `{type: "array", items: {type: "string", format: "date-time"}, minItems: 2, maxItems: 2}` |
| `z.tuple([z.number(), z.string()])` | `{type: "array", items: {oneOf: [{type: "number", format: "float"}, {type: "string"}]}, minItems: 2, maxItems: 2}` |
| `z.tuple([z.string()]).rest(z.string())` | `{type: "array", items: {type: "string"}, minItems: 1}` |

`getTupleRest` is added to the zod compat layer alongside the existing `getTupleItems`; both Zod 3 and Zod 4 keep the rest type at `def.rest`, so the existing `getDef` split covers it.

`zod-to-ts` already handled `ZodTuple`, so the generated TypeScript types are unchanged — this only affects the OpenAPI output.

## Testing

- `yarn workspace nextlove build`, `typecheck`, and `test` (8 tests) pass.
- Example-app OpenAPI generation tests pass (9 tests), including three new assertions covering the homogeneous, heterogeneous, and variadic cases above.

---
_Generated by [Claude Code](https://claude.ai/code/session_013zayu5zwnZjsQXjNhDmsLF)_